### PR TITLE
Fix: "blazor.boot.json.gz" and "blazor.boot.json.br" are removed undesirably

### DIFF
--- a/src/BlazorWasmAntivirusProtection.Tasks/BlazorWasmAntivirusProtection.Tasks.csproj
+++ b/src/BlazorWasmAntivirusProtection.Tasks/BlazorWasmAntivirusProtection.Tasks.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 

--- a/src/BlazorWasmAntivirusProtection/build/net6.0/BlazorWasmAntivirusProtection.targets
+++ b/src/BlazorWasmAntivirusProtection/build/net6.0/BlazorWasmAntivirusProtection.targets
@@ -33,7 +33,7 @@
 
 	<!-- Runs in the published project (server if hosted)-->
 	<Target Name="_ChangeDLLFileExtensions" AfterTargets="Publish">
-		<RenameDlls PublishDir="$(PublishDir)" RenameDllsTo="$(RenameDllsTo)" DisableRenamingDlls="$(DisableRenamingDlls)"></RenameDlls>
+		<RenameDlls PublishDir="$(PublishDir)" RenameDllsTo="$(RenameDllsTo)" DisableRenamingDlls="$(DisableRenamingDlls)" BlazorEnableCompression="$(BlazorEnableCompression)" CompressionLevel="$(_BlazorBrotliCompressionLevel)"></RenameDlls>
 	</Target>
 
 </Project>


### PR DESCRIPTION
At first, thank you for your great work!

By the way, this package will remove compressed "blazor.boot.json" files after the renaming process (The source code is [here](https://github.com/stavroskasidis/BlazorWasmAntivirusProtection/blob/4a6acb8fc18076ff1777e75d69ed5b07b3cc4676/src/BlazorWasmAntivirusProtection.Tasks/RenameDlls.cs#L81) and [here](https://github.com/stavroskasidis/BlazorWasmAntivirusProtection/blob/4a6acb8fc18076ff1777e75d69ed5b07b3cc4676/src/BlazorWasmAntivirusProtection.Tasks/RenameDlls.cs#L86)). Unfortunately, that behavior caused the runtime error when the Blazor Wasm app tried to load the compressed version of the "blazor.boot.json" file at its startup.

![](https://user-images.githubusercontent.com/43729469/199761766-73b10378-fc67-4b69-adb0-abe9635ee3e6.png)

- See also: https://github.com/jsakamoto/BlazorWasmPreRendering.Build/issues/22#issuecomment-1302276022

So, could you accept this pull request containing the program's changes to make it recompress the updated  "blazor.boot.json" file?

P.S. I updated the target framework version of the build task project from "netstandard2.0" to "net6.0" to use the "System.IO.Compression.Brotli" to recompress the "blazor.boot.json" with Brotli algorithm. ("System.IO.Compression.Brotli" class is not contained in the ".NET Standard 2.0" specification.) I think this target framework changins is no matter because this package is already depends on .NET SDK ver.6.0.