### PR TITLE
Fix the error of the custom task could not be loaded

### DIFF
--- a/src/BlazorWasmAntivirusProtection.BrotliCompress/BlazorWasmAntivirusProtection.BrotliCompress.csproj
+++ b/src/BlazorWasmAntivirusProtection.BrotliCompress/BlazorWasmAntivirusProtection.BrotliCompress.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/BlazorWasmAntivirusProtection.BrotliCompress/Program.cs
+++ b/src/BlazorWasmAntivirusProtection.BrotliCompress/Program.cs
@@ -1,0 +1,21 @@
+﻿using System.IO.Compression;
+
+try
+{
+    var bootJsonPath = args[0];
+    var bootJsonBrPath = args[1];
+    var compressionLeveText = args[2];
+
+    File.Delete(bootJsonBrPath);
+    var compressionLevel = Enum.TryParse<CompressionLevel>(compressionLeveText, out var level) ? level : CompressionLevel.Optimal;
+    using var fileStream = File.OpenRead(bootJsonPath);
+    using var stream = File.Create(bootJsonBrPath);
+    using var destination = new BrotliStream(stream, compressionLevel);
+    fileStream.CopyTo(destination);
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine(ex.ToString());
+    return 1;
+}

--- a/src/BlazorWasmAntivirusProtection.Tasks/BlazorWasmAntivirusProtection.Tasks.csproj
+++ b/src/BlazorWasmAntivirusProtection.Tasks/BlazorWasmAntivirusProtection.Tasks.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <!--
+        IMPORTANT: MSBuild Custom Task must target .NET Standard 2.0.
+                   Because an MSBuild Custom Task will run on both .NET (.NET Core) and .NET Framework.
+                   When users build a project with Visual Studio on Windows, the build process will be run on .NET Framework 4.x, 
+                   and when users build a project with .NET CLI (dotnet command), the build process will be run on .NET (.NET Core).
+        -->
+        <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 

--- a/src/BlazorWasmAntivirusProtection.Tasks/RenameDlls.cs
+++ b/src/BlazorWasmAntivirusProtection.Tasks/RenameDlls.cs
@@ -17,6 +17,9 @@ namespace BlazorWasmAntivirusProtection.Tasks
         [Required]
         public string PublishDir { get; set; }
 
+        [Required]
+        public string BrotliCompressToolPath { get; set; }
+
         public string RenameDllsTo { get; set; } = "bin";
         public bool DisableRenamingDlls { get; set; }
         public bool BlazorEnableCompression { get; set; } = true;
@@ -114,12 +117,19 @@ namespace BlazorWasmAntivirusProtection.Tasks
         {
             try
             {
-                File.Delete(bootJsonBrPath);
-                var compressionLevel = Enum.TryParse<CompressionLevel>(CompressionLevel, out var level) ? level : System.IO.Compression.CompressionLevel.Optimal;
-                using var fileStream = File.OpenRead(bootJsonPath);
-                using var stream = File.Create(bootJsonBrPath);
-                using var destination = new BrotliStream(stream, compressionLevel);
-                fileStream.CopyTo(destination);
+                // NOTE: This MSBuild Custom Task will run not only on .NET 6 or later but also on .NET Framework 4.x.
+                //       Therefore the `BrotliStream` class is not usable in this MSBuild Custom Task due to
+                //       the `BrotliStream` class is not provided on.NET Framework.Instead, we can do that
+                //       with execution as an out process.
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    Arguments = $"exec \"{BrotliCompressToolPath}\" \"{bootJsonPath}\" \"{bootJsonBrPath}\" \"{CompressionLevel}\""
+                };
+                Log.LogMessage(MessageImportance.Low, $"{startInfo.FileName} {startInfo.Arguments}");
+                var process = Process.Start(startInfo);
+                process.WaitForExit();
+                if (process.ExitCode != 0) throw new Exception($"The exit code of recompressing with Brotli command was not 0. (it was {process.ExitCode})");
             }
             catch (Exception ex)
             {

--- a/src/BlazorWasmAntivirusProtection.sln
+++ b/src/BlazorWasmAntivirusProtection.sln
@@ -36,15 +36,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "configs", "configs", "{298E
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorHostedSampleLazyLoading.Server", "..\sampleapps\BlazorHostedSampleLazyLoading\Server\BlazorHostedSampleLazyLoading.Server.csproj", "{9E4C4D90-0E4C-4679-AD28-7F990B286344}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHostedSampleLazyLoading.Server", "..\sampleapps\BlazorHostedSampleLazyLoading\Server\BlazorHostedSampleLazyLoading.Server.csproj", "{9E4C4D90-0E4C-4679-AD28-7F990B286344}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorHostedSampleLazyLoading.Client", "..\sampleapps\BlazorHostedSampleLazyLoading\Client\BlazorHostedSampleLazyLoading.Client.csproj", "{ABC6E5FE-4B5E-42AC-A955-35754B2805A7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHostedSampleLazyLoading.Client", "..\sampleapps\BlazorHostedSampleLazyLoading\Client\BlazorHostedSampleLazyLoading.Client.csproj", "{ABC6E5FE-4B5E-42AC-A955-35754B2805A7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorHostedSampleLazyLoading.Shared", "..\sampleapps\BlazorHostedSampleLazyLoading\Shared\BlazorHostedSampleLazyLoading.Shared.csproj", "{4C7F227E-2E90-4D0B-960D-0247DA937117}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHostedSampleLazyLoading.Shared", "..\sampleapps\BlazorHostedSampleLazyLoading\Shared\BlazorHostedSampleLazyLoading.Shared.csproj", "{4C7F227E-2E90-4D0B-960D-0247DA937117}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BlazorHostedSampleLazyLoading", "BlazorHostedSampleLazyLoading", "{B8531AC8-E394-4875-AB1F-3167F4C7149C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorHostedSampleLazyLoading.Counter", "..\sampleapps\BlazorHostedSampleLazyLoading\BlazorHostedSampleLazyLoading.Counter\BlazorHostedSampleLazyLoading.Counter.csproj", "{D1EC6118-9D76-42C1-9F4B-E9819AEC6472}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHostedSampleLazyLoading.Counter", "..\sampleapps\BlazorHostedSampleLazyLoading\BlazorHostedSampleLazyLoading.Counter\BlazorHostedSampleLazyLoading.Counter.csproj", "{D1EC6118-9D76-42C1-9F4B-E9819AEC6472}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWasmAntivirusProtection.BrotliCompress", "BlazorWasmAntivirusProtection.BrotliCompress\BlazorWasmAntivirusProtection.BrotliCompress.csproj", "{9DE33910-2E2E-484D-A9F6-686A362F78FC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -100,6 +102,10 @@ Global
 		{D1EC6118-9D76-42C1-9F4B-E9819AEC6472}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1EC6118-9D76-42C1-9F4B-E9819AEC6472}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1EC6118-9D76-42C1-9F4B-E9819AEC6472}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DE33910-2E2E-484D-A9F6-686A362F78FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DE33910-2E2E-484D-A9F6-686A362F78FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DE33910-2E2E-484D-A9F6-686A362F78FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DE33910-2E2E-484D-A9F6-686A362F78FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BlazorWasmAntivirusProtection/BlazorWasmAntivirusProtection.csproj
+++ b/src/BlazorWasmAntivirusProtection/BlazorWasmAntivirusProtection.csproj
@@ -30,5 +30,15 @@
         </ItemGroup>
     </Target>
 
+  <Target Name="GetToolsOutputDlls" BeforeTargets="CoreCompile">
+    <MSBuild Projects="..\BlazorWasmAntivirusProtection.BrotliCompress\BlazorWasmAntivirusProtection.BrotliCompress.csproj" Targets="Publish;PublishItemsOutputGroup" Properties="Configuration=$(Configuration)">
+      <Output TaskParameter="TargetOutputs" ItemName="_ToolsProjectOutputs" />
+    </MSBuild>
+    <ItemGroup>
+      <Content Include="@(_ToolsProjectOutputs)" Condition="('$(Configuration)' == 'Release' And '%(_ToolsProjectOutputs.Extension)' == '.dll')
+					                                            Or ('$(Configuration)' == 'Debug' And ('%(_ToolsProjectOutputs.Extension)' == '.dll' Or '%(_ToolsProjectOutputs.Extension)' == '.pdb'))
+                                                      Or ('%(_ToolsProjectOutputs.Extension)' == '.json')" Pack="true" PackagePath="tools\%(_ToolsProjectOutputs.TargetPath)" KeepMetadata="Pack;PackagePath" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/BlazorWasmAntivirusProtection/build/net7.0/BlazorWasmAntivirusProtection.targets
+++ b/src/BlazorWasmAntivirusProtection/build/net7.0/BlazorWasmAntivirusProtection.targets
@@ -8,6 +8,7 @@
 
 	<PropertyGroup>
 		<ComputeBlazorExtensionsDependsOn>$(ComputeBlazorExtensionsDependsOn);_ObfuscateDlls</ComputeBlazorExtensionsDependsOn>
+		<_BlazorWAPBrotliCompressDll>$(MSBuildThisFileDirectory)..\..\tools\BlazorWasmAntivirusProtection.BrotliCompress.dll</_BlazorWAPBrotliCompressDll>
 	</PropertyGroup>
 	
 	<!-- Runs in the client project -->
@@ -33,7 +34,7 @@
 
 	<!-- Runs in the published project (server if hosted)-->
 	<Target Name="_ChangeDLLFileExtensions" AfterTargets="Publish">
-		<RenameDlls PublishDir="$(PublishDir)" RenameDllsTo="$(RenameDllsTo)" DisableRenamingDlls="$(DisableRenamingDlls)" BlazorEnableCompression="$(BlazorEnableCompression)" CompressionLevel="$(_BlazorBrotliCompressionLevel)"></RenameDlls>
+		<RenameDlls PublishDir="$(PublishDir)" RenameDllsTo="$(RenameDllsTo)" DisableRenamingDlls="$(DisableRenamingDlls)" BlazorEnableCompression="$(BlazorEnableCompression)" CompressionLevel="$(_BlazorBrotliCompressionLevel)" BrotliCompressToolPath="$(_BlazorWAPBrotliCompressDll)"></RenameDlls>
 	</Target>
 
 </Project>


### PR DESCRIPTION
- Revert the target framework of the custom task project to .NET Standard 2.0.
- Make the Brotli compression process an out process.

(About Issue #36 )