### PR TITLE
Allow cache busting the initializer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ You can disable boot resources caching by using the following property in your C
 <BlazorCacheBootResources>false</BlazorCacheBootResources>
 ```
 
+### **Control browser cache for initializer script**
+The following property can be set to prevent the browser from caching the initializer script. 
+```xml
+<ScriptQueryString>1234</ScriptQueryString>
+```
+
 ## Samples / Demo
 You can find a sample app using this package [here](https://blazor-antivirus-block.azurewebsites.net/). 
 
@@ -103,6 +109,11 @@ You can see its [virustotal.com](https://www.virustotal.com/) scan result [here]
 This work was inspired by the post in https://github.com/dotnet/aspnetcore/issues/31048#issuecomment-915152791  by github user [tedd](https://github.com/tedd)
 
 ## Release Notes
+
+<details open="open"><summary>2.5.0</summary>
+    
+>- Allow appending a query string to the end of the initializer script to prevent browser from caching it.
+</details>
 
 <details open="open"><summary>2.4.0</summary>
     

--- a/src/BlazorWasmAntivirusProtection.Tasks/RenameDlls.cs
+++ b/src/BlazorWasmAntivirusProtection.Tasks/RenameDlls.cs
@@ -19,6 +19,7 @@ namespace BlazorWasmAntivirusProtection.Tasks
         [Required]
         public string BrotliCompressToolPath { get; set; }
 
+        public string ScriptQueryString { get; set; }
         public string RenameDllsTo { get; set; } = "bin";
         public bool DisableRenamingDlls { get; set; }
         public bool BlazorEnableCompression { get; set; } = true;
@@ -56,6 +57,11 @@ namespace BlazorWasmAntivirusProtection.Tasks
 
                 Log.LogMessage(MessageImportance.High, $"BlazorWasmAntivirusProtection: Updating \"{bootJsonPath}\"");
                 var bootJson = File.ReadAllText(bootJsonPath);
+                if (!string.IsNullOrWhiteSpace(ScriptQueryString))
+                {
+                    Log.LogMessage(MessageImportance.High, $"BlazorWasmAntivirusProtection: Cache busting \"BlazorWasmAntivirusProtection.lib.module.js\" with query string: {ScriptQueryString}");
+                    bootJson = bootJson.Replace("BlazorWasmAntivirusProtection.lib.module.js", $"BlazorWasmAntivirusProtection.lib.module.js?cache={ScriptQueryString}");
+                }
                 bootJson = bootJson.Replace(".dll", $".{RenameDllsTo}");
                 File.WriteAllText(bootJsonPath, bootJson);
 

--- a/src/BlazorWasmAntivirusProtection/BlazorWasmAntivirusProtection.csproj
+++ b/src/BlazorWasmAntivirusProtection/BlazorWasmAntivirusProtection.csproj
@@ -11,7 +11,7 @@
 		<PackageProjectUrl>https://github.com/stavroskasidis/BlazorWasmAntivirusProtection</PackageProjectUrl>
 		<Description>This package attempts to guard against false positives from antiviruses that flag Blazor Wasm as malware</Description>
 		<VersionSuffix>$(VersionSuffix)</VersionSuffix>
-		<Version>2.4.0</Version>
+		<Version>2.5.0</Version>
 		<Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
     </PropertyGroup>
 

--- a/src/BlazorWasmAntivirusProtection/build/net6.0/BlazorWasmAntivirusProtection.targets
+++ b/src/BlazorWasmAntivirusProtection/build/net6.0/BlazorWasmAntivirusProtection.targets
@@ -36,7 +36,7 @@
 
 	<!-- Runs in the published project (server if hosted)-->
 	<Target Name="_ChangeDLLFileExtensions" AfterTargets="Publish">
-		<RenameDlls PublishDir="$(PublishDir)" RenameDllsTo="$(RenameDllsTo)" DisableRenamingDlls="$(DisableRenamingDlls)" 
+		<RenameDlls PublishDir="$(PublishDir)" RenameDllsTo="$(RenameDllsTo)" ScriptQueryString="$(ScriptQueryString)" DisableRenamingDlls="$(DisableRenamingDlls)" 
 					BlazorEnableCompression="$(BlazorEnableCompression)" CompressionLevel="$(_BlazorBrotliCompressionLevel)"
 					BrotliCompressToolPath="$(_BlazorWAPBrotliCompressDll)">
 		</RenameDlls>


### PR DESCRIPTION
Fixes the following issue by appending a user controlled query string to then end of the initializer script in blazor.boot.json.
https://github.com/stavroskasidis/BlazorWasmAntivirusProtection/issues/46#issue-1564717263

Tested this on my own application and this solves the issue.
Also its opt-in, so if the users dont specifiy a query string it won't do anything extra.

